### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,7 @@ jobs:
 
     - name: Install package
       run: python -m pip install .[full]
+
+    # Tests are not ready to run in CI yet, so just do a basic import test
+    - name: Test import
+      run: python -c "import chaosmagpy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
     
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+        - os: ubuntu-20.04
+          python-version: 3.6
+        - os: ubuntu-22.04
+          python-version: 3.7
     
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ setup-ci ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # Weekly on Sunday
+    - cron: "0 1 * * 0"
+
+jobs:
+  checks:
+    name: Check Python ${{ matrix.python-version }} on ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install package
+      run: python -m pip install .[full]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
         runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
-        - runs-on: ubuntu-20.04
-          python-version: 3.6
         - runs-on: ubuntu-22.04
           python-version: 3.7
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
-        - os: ubuntu-20.04
+        - runs-on: ubuntu-20.04
           python-version: 3.6
-        - os: ubuntu-22.04
+        - runs-on: ubuntu-22.04
           python-version: 3.7
     
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,15 @@ build-backend = "setuptools.build_meta"
 name = "chaosmagpy"
 dynamic = ["version", "readme"]
 dependencies = [
-  "numpy>=2",
+  "numpy; python_version <= '3.11'",
+  "numpy>=2; python_version >= '3.12'",
   "scipy",
   "pandas",
   "Cython",
   "h5py",
   "pyshp>=2.3.1",
-  "hdf5storage>=0.2"
+  "hdf5storage; python_version <= '3.11'",
+  "hdf5storage>=0.2; python_version >= '3.12'",
 ]
 requires-python = ">=3.6"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ classifiers = [
 
 [project.optional-dependencies]
 full = [
-  "matplotlib>=3.6",
+  "matplotlib; python_version <= '3.7'",
+  "matplotlib>=3.6; python_version >= '3.8'",
   "lxml>=4.3.4"
 ]
 


### PR DESCRIPTION
See #13 

This will help to catch installation issues before humans stumble into them :)

I've also snuck in the conditional dependency switches, e.g.:
```
 "hdf5storage; python_version <= '3.11'",
 "hdf5storage>=0.2; python_version >= '3.12'",
```
which makes it install without issue on the older python versions (*but* the code functionality is still not actually tested).

Setting up GitHub Actions is a bit of a special skill (see e.g. https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job) so I'm happy to help out here. It will need a little maintenance over time but I'll keep an eye on that.

I'll break it down a little:

workflow control:
```
on:
  workflow_dispatch:
  push:
    branches: [ setup-ci ]
  pull_request:
    branches: [ master ]
  schedule:
    # Weekly on Sunday
    - cron: "0 1 * * 0"
 ```
this says that we run it on:
- a manual trigger through github web ui (`workflow_dispatch`) - this can be helpful if there is a temporary problem, and you just want to rerun it
- any push to the `setup-ci` branch (I just use this to test setting it up, so will remove it before we merge / switch to `master`)
- any pull request to `master`
- once a week on Sunday - this can get annoying if it's repeatedly failing, but I find weekly is a reasonable balance to be notified and maybe fix it in the week - but it's a motivation to make the installation and tests robust!

platforms / Python versions:
```
      matrix:
        runs-on: ["ubuntu-latest", "macos-latest", "windows-latest"]
        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
        include:
        - runs-on: ubuntu-22.04
          python-version: 3.7
```
defines the machines it is tested on. It'll break once Python 3.8 becomes unsupported on the "latest" machines provided, hence the extra `include` part just to keep a test on Python 3.7. We adjust this a little over time. Basically this means we install the package against the latest dependency versions on a "new" machine, and see if anything breaks.

You can see an example of the test matrix here: https://github.com/smithara/ChaosMagPy/actions/runs/16076908430

test code:
```
    - name: Install package
      run: python -m pip install .[full]

    # Tests are not ready to run in CI yet, so just do a basic import test
    - name: Test import
      run: python -c "import chaosmagpy"
```
... simply testing the installation and a basic import. It's an easy first step, but we can extend here with more "real" tests.
