### PR TITLE
Fix Some Misspellings

### DIFF
--- a/chaosmagpy/chaos.py
+++ b/chaosmagpy/chaos.py
@@ -2566,7 +2566,7 @@ str, {'internal', 'external'}
             nmax = self.model_static.nmax
             order = 1
 
-            # create additonal header lines
+            # create additional header lines
             header = textwrap.dedent(f"""\
                 # {self.name}
                 # Spherical harmonic coefficients (units of nT) of the static

--- a/chaosmagpy/coordinate_utils.py
+++ b/chaosmagpy/coordinate_utils.py
@@ -288,7 +288,7 @@ def coupling_Newell(By, Bz, Vx):
     Notes
     -----
     Newell's coupling function is proportional to the rate at which magnetic
-    flux is openend on the dayside of the magnetopause through reconnection.
+    flux is opened on the dayside of the magnetopause through reconnection.
 
     The original definition of the coupling function only differs in the
     factor :math:`10^{-3}`, which is included in the definition used here:
@@ -531,7 +531,7 @@ shape (``filter``, ``nmax`` (``nmax`` + 2), ``kmax`` (``kmax`` + 2))
 
     for k in range(nmax*(nmax+2)):
 
-        # compute Q-response for freqencies and given Gauss coefficient
+        # compute Q-response for frequencies and given Gauss coefficient
         response = qfunc(frequency_full, k)
 
         for ll in range(kmax*(kmax+2)):
@@ -1948,7 +1948,7 @@ def q_response_1D(periods, sigma, radius, n, kind=None):
         fac1 = factorial(n)
         fac2 = (-1)**n * fac1/(2*n+1)
 
-        # initialze helpers variables and output
+        # initialize helpers variables and output
         C = np.empty(periods.shape, dtype=complex)
         z = np.empty((2,), dtype=complex)
         p = np.empty((2,), dtype=complex)

--- a/chaosmagpy/data_utils.py
+++ b/chaosmagpy/data_utils.py
@@ -298,7 +298,7 @@ def save_shcfile(time, coeffs, order=None, filepath=None, nmin=None, nmax=None,
     Parameters
     ----------
     time : float, list, ndarray, shape (n,)
-        Time of model coeffcients in modified Julian date.
+        Time of model coefficients in modified Julian date.
     coeffs : ndarray, shape (N,) or (n, N)
         Gauss coefficients as vector or array. The first dimension of the array
         must be equal to the length `n` of the given ``time``.
@@ -313,7 +313,7 @@ def save_shcfile(time, coeffs, order=None, filepath=None, nmin=None, nmax=None,
         first values from coeffs if greater than 1.
     nmax : int, optional
         Maximum spherical harmonic degree (defaults to degree compatible with
-        number of coeffcients, otherwise coeffcients are truncated).
+        number of coefficients, otherwise coefficients are truncated).
     leap_year : {True, False}, optional
         Take leap years for decimal year conversion into account
         (defaults to ``True``).

--- a/chaosmagpy/model_utils.py
+++ b/chaosmagpy/model_utils.py
@@ -837,7 +837,7 @@ def design_gauss(radius, theta, phi, nmax, *, nmin=None, mmax=None,
     else:
         dim = int((nmax-nmin+1)*(2*mmax+1))
 
-    # allocate A_radius, A_theta, A_phi in memeory
+    # allocate A_radius, A_theta, A_phi in memory
     A_radius = np.zeros(shape + (dim,))
     A_theta = np.zeros(shape + (dim,))
     A_phi = np.zeros(shape + (dim,))
@@ -930,7 +930,7 @@ def legendre_poly(nmax, theta):
 
     Pnm = np.zeros((nmax+1, nmax+2) + costh.shape)
     Pnm[0, 0] = 1.  # is copied into trailing dimensions
-    Pnm[1, 1] = sinth  # write theta into trailing dimenions via broadcasting
+    Pnm[1, 1] = sinth  # write theta into trailing dimensions via broadcasting
 
     rootn = np.sqrt(np.arange(2 * nmax**2 + 1))
 

--- a/tests/test_chaos.py
+++ b/tests/test_chaos.py
@@ -62,7 +62,7 @@ class Chaos(TestCase):
         filepath = os.path.join(ROOT, filename)
 
         model = cp.load_CHAOS_matfile(CHAOS_PATH)
-        print('  ', end='')  # indent line by two withespaces
+        print('  ', end='')  # indent line by two whitespaces
         model.save_matfile(filepath)
 
         def test(x, y):

--- a/tests/test_coordinate_utils.py
+++ b/tests/test_coordinate_utils.py
@@ -200,7 +200,7 @@ class CoordinateUtils(TestCase):
 
     def test_synth_rotate_gauss(self):
         """
-        Tests the accuracy of the Fourier representation of tranformation
+        Tests the accuracy of the Fourier representation of transformation
         matrices by comparing them with directly computed matrices (they are
         considered correct).
 


### PR DESCRIPTION
This PR fixes some misspellings detected via `typos` (used as a `pre-commit` hook; see the issue for more details).